### PR TITLE
Make classes public so we can use them from embedding app using cocoapod...

### DIFF
--- a/Recorder.podspec
+++ b/Recorder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Recorder"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "Record and export a view hierarchy to PNG or JPEG frames for flip book style animations (as used in WatchKit)."
 
   s.description  = <<-DESC
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.author             = { "Andy Drizen" => "andydrizen@gmail.com" }
   s.social_media_url   = "http://twitter.com/andydrizen"
   s.platform     = :ios, '7.0'
-  s.source       = { :git => "https://github.com/andydrizen/UIViewRecorder.git", :tag => "0.0.1" }
+  s.source       = { :git => "https://github.com/andydrizen/UIViewRecorder.git", :tag => "0.0.2" }
   s.source_files  = "Recorder.swift"
 end

--- a/Recorder.podspec
+++ b/Recorder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Recorder"
-  s.version      = "0.0.2"
+  s.version      = "0.0.3"
   s.summary      = "Record and export a view hierarchy to PNG or JPEG frames for flip book style animations (as used in WatchKit)."
 
   s.description  = <<-DESC
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.author             = { "Andy Drizen" => "andydrizen@gmail.com" }
   s.social_media_url   = "http://twitter.com/andydrizen"
   s.platform     = :ios, '7.0'
-  s.source       = { :git => "https://github.com/andydrizen/UIViewRecorder.git", :tag => "0.0.2" }
+  s.source       = { :git => "https://github.com/andydrizen/UIViewRecorder.git", :tag => "0.0.3" }
   s.source_files  = "Recorder.swift"
 end

--- a/Recorder.swift
+++ b/Recorder.swift
@@ -8,16 +8,16 @@
 
 import UIKit
 
-class Recorder: NSObject {
+public class Recorder: NSObject {
     var displayLink : CADisplayLink?
     
     var imageCounter = 0
-    var view : UIView?
+    public var view : UIView?
     var outputPath : NSString?
     var referenceDate : NSDate?
     var outputJPG = false
     
-    func start() {
+    public func start() {
         
         if (view == nil) {
             NSException(name: "No view set", reason: "You must set a view before calling start.", userInfo: nil).raise()
@@ -30,7 +30,7 @@ class Recorder: NSObject {
         }
     }
     
-    func stop() {
+    public func stop() {
         displayLink?.invalidate()
         
         let seconds = referenceDate?.timeIntervalSinceNow

--- a/Recorder.swift
+++ b/Recorder.swift
@@ -15,7 +15,8 @@ public class Recorder: NSObject {
     public var view : UIView?
     var outputPath : NSString?
     var referenceDate : NSDate?
-    var outputJPG = false
+    public var name = "image"
+    public var outputJPG = false
     
     public func start() {
         
@@ -78,7 +79,7 @@ public class Recorder: NSObject {
         
         imageCounter = imageCounter + 1
         var path = outputPathString()
-        path = path.stringByAppendingPathComponent("/image\(imageCounter).\(fileExtension)")
+        path = path.stringByAppendingPathComponent("/\(name)\(imageCounter).\(fileExtension)")
         
         data!.writeToURL(NSURL(string: path)!, atomically: false)
         

--- a/Recorder.swift
+++ b/Recorder.swift
@@ -77,9 +77,10 @@ public class Recorder: NSObject {
             data = UIImagePNGRepresentation(image)
         }
         
-        imageCounter = imageCounter + 1
         var path = outputPathString()
-        path = path.stringByAppendingPathComponent("/\(name)\(imageCounter).\(fileExtension)")
+        path = path.stringByAppendingPathComponent("/\(name)-\(imageCounter).\(fileExtension)")
+        
+        imageCounter = imageCounter + 1
         
         data!.writeToURL(NSURL(string: path)!, atomically: false)
         


### PR DESCRIPTION
I wasn't able to use your recorder though cocoapods, so I made the classes and some methods public.

If you accept this pull request, you should probably also set the new tag version 0.0.2 to your repo.

By the way, great strategy to record animations targeted to the WATCH.
