### PR TITLE
Objective C support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Simply add this class into your project.
 
 # Usage
 
+## In your Swift code
+
 Create an instance of Recorder and set the view that you wish to record:
 
 ```
@@ -23,6 +25,29 @@ and when you are finished:
 
 ```
 recorder.stop()
+```
+
+## In your Objective C code
+
+Before start, make sure your `UIViewRecorder` code has been properly integrated in your Objective C project. Refeer to official Apple guide [Swift and Objective-C in the Same Project](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html#//apple_ref/doc/uid/TP40014216-CH10-XID_75) section *Importing Swift into Objective-C*.
+
+Create an instance of Recorder and set the view that you wish to record:
+
+```
+Recorder *myRecorder = [[Recorder alloc] init];
+myRecorder.view = activityIndicator;
+```
+
+When you are ready to start recording, simply:
+
+```
+[myRecorder start];
+```
+
+and when you are finished:
+
+```
+[myRecorder stop];
 ```
 
 # Output

--- a/Recorder.swift
+++ b/Recorder.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class Recorder: NSObject {
+@objc public class Recorder: NSObject {
     var displayLink : CADisplayLink?
     
     var imageCounter = 0

--- a/Recorder.swift
+++ b/Recorder.swift
@@ -82,7 +82,9 @@ public class Recorder: NSObject {
         
         imageCounter = imageCounter + 1
         
-        data!.writeToURL(NSURL(string: path)!, atomically: false)
+        if let imageRaw = data {
+            imageRaw.writeToURL(NSURL(string: path)!, atomically: false)
+        }
         
         UIGraphicsEndImageContext();
     }


### PR DESCRIPTION
# Summary

Use a _Recorder_ object in Objective C classes. 
# Why

Could happen that an app that is going to include an Apple Watch target, is inheriting source files written in Objective C.
# How I use it

Create an instance of Recorder and set the view that you wish to record:

```
Recorder *myRecorder = [[Recorder alloc] init];
myRecorder.view = activityIndicator;
```

When you are ready to start recording, simply:

```
[myRecorder start];
```

and when you are finished:

```
[myRecorder stop];
```
# Note

Refer to official Apple Documentation to properly integrate Swift code in Objective C source files: [Swift and Objective-C in the Same Project](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html#//apple_ref/doc/uid/TP40014216-CH10-XID_75)
